### PR TITLE
Fixed github actions (event type trigger changed to 'on push')

### DIFF
--- a/.github/workflows/node-gh-pages.yml
+++ b/.github/workflows/node-gh-pages.yml
@@ -1,6 +1,6 @@
 name: Build and Deploy
 on:
-  pull_request:
+  push:
     branches:
       - master
 


### PR DESCRIPTION
Cancel changes with type event in Github Actions script. Pull request fires too often. Push event suits better